### PR TITLE
Fix tank archive labeling

### DIFF
--- a/pages/tanks/[id].tsx
+++ b/pages/tanks/[id].tsx
@@ -111,6 +111,7 @@ export default function TankDetailPage() {
     await supabase.from("tank_archive").insert([
       {
         tank_id: tank.id,
+        tank_label: tank.tank_id,
         strain_id: tank.strain_id,
         total_fish: tank.total_fish,
         larval_count: tank.larval_count,


### PR DESCRIPTION
## Summary
- ensure tank label gets stored when archiving a tank

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3f10ba448333906beaba4e06c8ce