### PR TITLE
Add README with remote setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Zebrafish Tracker
+
+This repository contains a Next.js project.
+
+## Remote Repository Setup
+
+This environment does not have a remote Git repository configured. If you want to
+push your changes to a remote (e.g., GitHub), first add a remote:
+
+```bash
+git remote add origin <your-repo-url>
+```
+
+Then push the main branch (or whichever branch you are using):
+
+```bash
+git push -u origin main
+```
+
+Replace `<your-repo-url>` with the URL of your GitHub repository.
+
+## Running the App
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Note on This Environment
+
+The Codex environment used to generate this project has no internet access,
+so remote commands like `git push` will fail here. Perform these steps on your
+own machine with internet connectivity.
+


### PR DESCRIPTION
## Summary
- add a README describing how to configure a remote repository and run the dev server
- document environment limitations for pushing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7566e7c4833383c7bd65bbeea3cd